### PR TITLE
Store fine-grained PAT in OS keyring with file fallback (closes #5)

### DIFF
--- a/docs/ADR/0001-keyring-credential-store.md
+++ b/docs/ADR/0001-keyring-credential-store.md
@@ -1,0 +1,151 @@
+# ADR-0001: Use OS keyring for fine-grained PAT storage with file-based fallback
+
+## Status
+
+Proposed (will move to **Accepted** upon merge of the PR that closes Issue #5).
+
+## Context
+
+GitFive-Go authenticates to the GitHub REST API and to `git` operations using a
+fine-grained Personal Access Token (PAT). After PR #14 the PAT is the *only*
+secret the application stores — username, password, and 2FA flow have been
+removed.
+
+Through v0.1.1, the PAT was persisted as base64-encoded JSON at
+`~/.gitfive_go/creds.m`, with file mode `0600`. This was inherited from the
+Python upstream and was never meaningful protection: any same-user process can
+read the file, any backup tool that includes dotfiles captures the secret in
+plaintext-equivalent form, and the obfuscation discourages neither casual
+inspection nor automated credential scrapers.
+
+Issue #5 asks for a real OS-level secret store. The fine-grained PAT migration
+makes the upgrade more valuable: the token now has `Administration: write` on
+all repositories owned by the user, so a compromise has higher blast radius
+than the previous classic PAT did.
+
+Constraints we must honor:
+
+- **Pure Go, no CGO.** The project ships static binaries with `CGO_ENABLED=0`
+  for cross-compilation; any keyring library that pulls in CGO is disqualified.
+- **Cross-platform.** The release matrix covers macOS (arm64, amd64), Linux
+  (arm64, amd64), and Windows (arm64, amd64). The same code path must work on
+  all six.
+- **Headless / CI compatibility.** The tool must remain usable on hosts where
+  no OS keyring is available — Docker containers without a D-Bus session,
+  SSH-only servers, sandboxed CI runners. Forcing keyring everywhere would
+  break those use cases.
+- **Existing v0.1.1 users must not be locked out.** Their on-disk creds files
+  must continue to read until the user re-authenticates.
+
+## Decision
+
+Adopt **`github.com/zalando/go-keyring`** as the primary credential backend,
+with a base64-encoded file as the fallback / opt-in alternative.
+
+**Why `zalando/go-keyring`:**
+
+- Pure Go on all three platforms (`/usr/bin/security` shell-out on macOS,
+  `godbus/dbus` pure-Go D-Bus on Linux, `syscall` on Windows). Compatible with
+  `CGO_ENABLED=0`.
+- Single small API surface (`Set` / `Get` / `Delete`).
+- Has a built-in mock (`keyring.MockInit`, `keyring.MockInitWithError`) that
+  allows deterministic unit tests without touching the real OS store.
+- Actively maintained at the time of writing.
+
+### Storage schema
+
+The on-disk file (`~/.gitfive_go/creds.m`, base64-encoded JSON) carries a
+`storage` marker telling readers where the token actually lives:
+
+```json
+// keyring backend (default)
+{"storage": "keyring"}
+
+// file backend (opt-in via --use-file-storage, or auto-fallback)
+{"storage": "file", "token": "github_pat_..."}
+```
+
+Legacy v0.1.1 files (no `storage` field, but a `token` field) are read
+transparently as the file backend; a subsequent `Save` rewrites them in the new
+format.
+
+The username field that previous versions persisted is dropped: it is rederived
+from `GET /user` on every `CheckToken` call, so persisting it added no value
+and produced stale data after token rotation.
+
+### Backend selection
+
+- **Default**: keyring. The login flow attempts `keyring.Set`. On success the
+  token is in the OS keyring and the file holds only a marker.
+- **Auto-fallback**: if `keyring.Set` returns an error (no D-Bus session,
+  Wincred unavailable, etc.) the login flow falls back to the file backend
+  with a one-line stderr warning so the user is not left silently confused on
+  a host that lacks keyring support.
+- **Explicit opt-in**: `gitfive-go login --use-file-storage` skips the keyring
+  attempt entirely and always writes file-backed credentials. Useful for
+  hosts where the keyring exists but the user prefers file storage (e.g.
+  for portability or to back up creds.m alongside other dotfiles).
+
+### Token rotation / cleanup
+
+- Every `Save` overwrites the entry on whichever backend is selected. The
+  *other* backend is best-effort cleared in the same call, so a user who
+  switches between keyring and file modes never leaves a recoverable token
+  behind on the unused backend.
+- `gitfive-go login --clean` removes both the keyring entry and the on-disk
+  file regardless of which was last used.
+- The existing 30-day expiry warning (PR #14) still prompts the user to
+  rotate before the PAT expires. The new `Save` flow guarantees the rotation
+  replaces the old token rather than leaving it adjacent.
+
+### Keyring identifiers
+
+Service: `gitfive-go`. Account: `fine-grained-pat`. Single fixed key — the
+tool does not support multiple PATs per host.
+
+## Consequences
+
+### Positive
+
+- The PAT is no longer trivially recoverable from a stolen home-directory
+  backup or a same-user process casually inspecting `~/.gitfive_go/`.
+- Aligns with mainstream macOS / Windows / Linux desktop expectations: the
+  Keychain / Credential Manager / Secret Service is where third-party CLIs
+  are expected to store credentials.
+- Token rotation is now safer: stale tokens are explicitly purged from the
+  unused backend on every `Save`, so a leaked token cannot survive in a
+  forgotten file after the user re-logs in.
+- Username is no longer persisted, eliminating one stale-data class.
+
+### Negative / risks
+
+- An additional dependency (`zalando/go-keyring` plus its transitive deps:
+  `godbus/dbus/v5`, `danieljoos/wincred`). All pure Go and static-build
+  compatible, but the supply-chain surface grows.
+- Two storage backends mean two code paths. We keep this manageable by hiding
+  the choice behind `internal/credstore.Store` and a single `storage` marker.
+- macOS keychain access via `/usr/bin/security` shells out for every read
+  and write. This is fine for our access pattern (tens of operations per
+  invocation) but is observably slower than a CGO-based binding would be.
+- Same-user attackers who can already execute code as the GitFive-Go user
+  retain a path to the token (they can call `keyring.Get` themselves). The
+  keyring raises the bar against backup-and-extract scenarios but does not
+  defend against an attacker who is already running on the box as our user.
+  This is consistent with how other CLI tools that use the OS keyring frame
+  their threat model.
+
+### Follow-ups
+
+- If usage patterns warrant, swap the macOS `/usr/bin/security` shell-out for
+  a direct Keychain Services binding (would require CGO; out of scope here).
+- Document the OS-specific GUI surface (Keychain Access, `seahorse`, Windows
+  Credential Manager) in a future user-facing README section so users can
+  inspect / revoke the entry by hand.
+
+## References
+
+- Issue: [#5](https://github.com/zackey-heuristics/GitFive-Go/issues/5)
+- Library: <https://github.com/zalando/go-keyring>
+- Prior work removing username/password and adopting fine-grained PATs: PR #14
+- Prior work routing git auth through `GIT_ASKPASS` (so this ADR's secret
+  never touches argv): PR #15

--- a/docs/ADR/0001-keyring-credential-store.md
+++ b/docs/ADR/0001-keyring-credential-store.md
@@ -92,8 +92,17 @@ and produced stale data after token rotation.
   *other* backend is best-effort cleared in the same call, so a user who
   switches between keyring and file modes never leaves a recoverable token
   behind on the unused backend.
-- `gitfive-go login --clean` removes both the keyring entry and the on-disk
-  file regardless of which was last used.
+- The same best-effort cleanup runs **even on the auto-fallback path**:
+  when a `BackendKeyring` request degrades to file storage because
+  `keyring.Set` failed, the `Save` flow still attempts `keyring.Delete` so
+  a stale PAT from a previous successful keyring login does not survive
+  the fallback.
+- `gitfive-go login --clean` removes both the keyring entry and the
+  on-disk file regardless of which was last used. Clean now propagates a
+  non-`NotFound` `keyring.Delete` error back to the caller (rather than
+  silently treating "delete failed" as success), so a locked / unavailable
+  keyring at clean time is reported instead of producing a misleading
+  "credentials cleared" message while the PAT remains recoverable.
 - The existing 30-day expiry warning (PR #14) still prompts the user to
   rotate before the PAT expires. The new `Save` flow guarantees the rotation
   replaces the old token rather than leaving it adjacent.

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,13 @@ require (
 
 require (
 	github.com/andybalholm/cascadia v1.3.3 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	github.com/zalando/go-keyring v0.2.8 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,10 +9,14 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdK
 github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=
 github.com/chengxilo/virtualterm v1.0.4/go.mod h1:DyxxBZz/x1iqJjFxTFcr6/x+jSpqN0iwWCOK1q10rlY=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -38,6 +42,8 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/internal/auth/credentials.go
+++ b/internal/auth/credentials.go
@@ -1,55 +1,95 @@
 package auth
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/zackey-heuristics/gitfive-go/internal/credstore"
 	"github.com/zackey-heuristics/gitfive-go/internal/util"
 )
 
 // Credentials holds the fine-grained PAT and the resolved GitHub username.
+//
+// Username is in-memory only — it is rederived from `GET /user` by
+// CheckToken on every Login flow, so persisting it is unnecessary. The
+// token is the only secret persisted, and it is delegated to credstore
+// (OS keyring or fallback file).
 type Credentials struct {
-	Username string `json:"username"`
-	Token    string `json:"token"`
+	Username string
+	Token    string
 
-	credsPath string
+	store *credstore.Store
+
+	// PreferredBackend selects the credstore backend used by Save. When
+	// unset, Save uses BackendKeyring (auto-falling back to file inside
+	// credstore on keyring failure).
+	PreferredBackend credstore.Backend
+
+	// ActiveBackend records which backend Save actually used after the
+	// last successful Save. Useful for user-facing messages such as
+	// "Token stored in OS keyring" vs "Token stored in file at ...".
+	ActiveBackend credstore.Backend
 }
 
-// NewCredentials initializes credential paths.
+// NewCredentials returns Credentials wired to the standard on-disk path.
 func NewCredentials() (*Credentials, error) {
 	dir, err := util.GitfiveDir()
 	if err != nil {
 		return nil, fmt.Errorf("credentials: %w", err)
 	}
 	return &Credentials{
-		credsPath: filepath.Join(dir, "creds.m"),
+		store: credstore.New(filepath.Join(dir, "creds.m")),
 	}, nil
 }
 
-// CredsPath returns the path to the credentials file.
-func (c *Credentials) CredsPath() string { return c.credsPath }
-
-// Load reads credentials from disk.
-func (c *Credentials) Load() {
-	if creds := parseFile(c.credsPath); creds != nil {
-		if v, ok := creds["username"].(string); ok {
-			c.Username = v
-		}
-		if v, ok := creds["token"].(string); ok {
-			c.Token = v
-		}
+// CredsPath returns the path to the credentials marker / fallback file.
+// Useful for diagnostics and the askpass error messages.
+func (c *Credentials) CredsPath() string {
+	if c.store == nil {
+		return ""
 	}
+	return c.store.CredsPath()
 }
 
-// Save writes credentials to disk.
+// Load reads credentials from disk (and the OS keyring if the marker says so).
+// Errors are silently ignored to preserve prior "best-effort" behaviour for
+// callers that only check AreLoaded(); explicit error reporting belongs at
+// login time.
+func (c *Credentials) Load() {
+	if c.store == nil {
+		return
+	}
+	tok, _, err := c.store.Load()
+	if err != nil {
+		// Surface a one-line warning so a corrupt creds.m is not silently
+		// invisible. Token stays empty; AreLoaded() will return false and
+		// callers will route the user to `gitfive-go login`.
+		fmt.Fprintf(os.Stderr, "[!] failed to load credentials: %v\n", err)
+		return
+	}
+	c.Token = tok
+}
+
+// Save writes the token via credstore using the configured PreferredBackend
+// (defaulting to BackendKeyring). Records the backend actually used in
+// ActiveBackend (which may differ from PreferredBackend if credstore fell
+// back from keyring to file). Username is in-memory only and is NOT
+// persisted.
 func (c *Credentials) Save() error {
-	return saveFile(c.credsPath, map[string]string{
-		"username": c.Username,
-		"token":    c.Token,
-	})
+	if c.store == nil {
+		return fmt.Errorf("credentials store not initialized")
+	}
+	backend := c.PreferredBackend
+	if backend == "" {
+		backend = credstore.BackendKeyring
+	}
+	used, err := c.store.Save(c.Token, backend)
+	if err != nil {
+		return err
+	}
+	c.ActiveBackend = used
+	return nil
 }
 
 // AreLoaded returns true if a token is present. Username is populated by
@@ -58,35 +98,11 @@ func (c *Credentials) AreLoaded() bool {
 	return c.Token != ""
 }
 
-// Clean removes the credentials file from disk.
+// Clean removes the token from BOTH backends (keyring + file). After a
+// successful Clean, no GitFive-Go credentials remain on the host.
 func (c *Credentials) Clean() error {
-	if err := os.Remove(c.credsPath); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	return nil
-}
-
-func parseFile(path string) map[string]interface{} {
-	data, err := os.ReadFile(path)
-	if err != nil {
+	if c.store == nil {
 		return nil
 	}
-	decoded, err := base64.StdEncoding.DecodeString(string(data))
-	if err != nil {
-		return nil
-	}
-	var result map[string]interface{}
-	if err := json.Unmarshal(decoded, &result); err != nil {
-		return nil
-	}
-	return result
-}
-
-func saveFile(path string, data interface{}) error {
-	jsonBytes, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return err
-	}
-	encoded := base64.StdEncoding.EncodeToString(jsonBytes)
-	return os.WriteFile(path, []byte(encoded), 0o600)
+	return c.store.Clean()
 }

--- a/internal/auth/credentials_test.go
+++ b/internal/auth/credentials_test.go
@@ -4,35 +4,53 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/zalando/go-keyring"
 )
 
-func TestCredentialsSaveLoad(t *testing.T) {
-	tmpDir := t.TempDir()
+// redirectHome redirects HOME (and USERPROFILE for Windows) so
+// NewCredentials anchors the store under a per-test temp directory and
+// resets the keyring mock so prior tests don't bleed in.
+func redirectHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	keyring.MockInit()
+	return home
+}
 
-	creds := &Credentials{
-		Username:  "testuser",
-		Token:     "github_pat_testtoken",
-		credsPath: filepath.Join(tmpDir, "creds.m"),
+func TestCredentialsSaveLoad(t *testing.T) {
+	home := redirectHome(t)
+
+	creds, err := NewCredentials()
+	if err != nil {
+		t.Fatal(err)
 	}
+	creds.Username = "testuser" // not persisted, just validates Save tolerates it
+	creds.Token = "github_pat_testtoken"
 
 	if err := creds.Save(); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := os.Stat(creds.credsPath); os.IsNotExist(err) {
+	credsPath := filepath.Join(home, ".gitfive_go", "creds.m")
+	if _, err := os.Stat(credsPath); os.IsNotExist(err) {
 		t.Fatal("creds file not created")
 	}
 
-	creds2 := &Credentials{
-		credsPath: creds.credsPath,
+	creds2, err := NewCredentials()
+	if err != nil {
+		t.Fatal(err)
 	}
 	creds2.Load()
-
-	if creds2.Username != "testuser" {
-		t.Errorf("expected username 'testuser', got %q", creds2.Username)
-	}
 	if creds2.Token != "github_pat_testtoken" {
 		t.Errorf("expected token 'github_pat_testtoken', got %q", creds2.Token)
+	}
+	// Username is intentionally NOT persisted; CheckToken repopulates it
+	// from `GET /user` on every login. Confirm that.
+	if creds2.Username != "" {
+		t.Errorf("Username must not be persisted, got %q", creds2.Username)
 	}
 }
 
@@ -49,29 +67,32 @@ func TestAreLoaded(t *testing.T) {
 }
 
 func TestClean(t *testing.T) {
-	tmpDir := t.TempDir()
-	credsPath := filepath.Join(tmpDir, "creds.m")
+	home := redirectHome(t)
 
-	if err := os.WriteFile(credsPath, []byte("data"), 0o600); err != nil {
+	creds, err := NewCredentials()
+	if err != nil {
+		t.Fatal(err)
+	}
+	creds.Token = "github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	if err := creds.Save(); err != nil {
 		t.Fatal(err)
 	}
 
-	creds := &Credentials{
-		credsPath: credsPath,
-	}
 	if err := creds.Clean(); err != nil {
 		t.Fatal(err)
 	}
 
+	credsPath := filepath.Join(home, ".gitfive_go", "creds.m")
 	if _, err := os.Stat(credsPath); !os.IsNotExist(err) {
-		t.Error("creds file should be deleted")
+		t.Error("creds file should be deleted by Clean")
 	}
 }
 
 func TestCleanIgnoresMissingFile(t *testing.T) {
-	tmpDir := t.TempDir()
-	creds := &Credentials{
-		credsPath: filepath.Join(tmpDir, "missing.m"),
+	redirectHome(t)
+	creds, err := NewCredentials()
+	if err != nil {
+		t.Fatal(err)
 	}
 	if err := creds.Clean(); err != nil {
 		t.Errorf("Clean on missing file should be a no-op, got %v", err)

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"golang.org/x/term"
+
+	"github.com/zackey-heuristics/gitfive-go/internal/credstore"
 )
 
 const (
@@ -223,7 +225,14 @@ func Login(creds *Credentials, force bool) error {
 	if err := creds.Save(); err != nil {
 		return fmt.Errorf("save credentials: %w", err)
 	}
-	fmt.Printf("[+] Credentials saved in %s\n", creds.CredsPath())
+	switch creds.ActiveBackend {
+	case credstore.BackendKeyring:
+		fmt.Printf("[+] Token stored in the OS keyring (marker file: %s)\n", creds.CredsPath())
+	case credstore.BackendFile:
+		fmt.Printf("[+] Token stored in %s (file storage)\n", creds.CredsPath())
+	default:
+		fmt.Printf("[+] Credentials saved in %s\n", creds.CredsPath())
+	}
 	return nil
 }
 

--- a/internal/commands/login.go
+++ b/internal/commands/login.go
@@ -6,12 +6,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/zackey-heuristics/gitfive-go/internal/auth"
+	"github.com/zackey-heuristics/gitfive-go/internal/credstore"
 )
 
 // NewLoginCmd creates the "login" subcommand.
 func NewLoginCmd() *cobra.Command {
 	var clean bool
 	var force bool
+	var useFileStorage bool
 
 	cmd := &cobra.Command{
 		Use:   "login",
@@ -22,9 +24,18 @@ func NewLoginCmd() *cobra.Command {
 				return err
 			}
 
+			// Apply backend selection BEFORE Save runs. The default is
+			// keyring; --use-file-storage forces the on-disk fallback even
+			// on hosts where keyring is available.
+			if useFileStorage {
+				creds.PreferredBackend = credstore.BackendFile
+			} else {
+				creds.PreferredBackend = credstore.BackendKeyring
+			}
+
 			if clean {
 				_ = creds.Clean()
-				fmt.Println("[+] Credentials file deleted!")
+				fmt.Println("[+] Credentials cleared (keyring entry and file).")
 				return nil
 			}
 
@@ -49,7 +60,9 @@ func NewLoginCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&clean, "clean", false, "Clear the credentials file")
+	cmd.Flags().BoolVar(&clean, "clean", false, "Clear the credentials (both keyring entry and file)")
 	cmd.Flags().BoolVar(&force, "force", false, "Re-authenticate even if a valid token is already saved")
+	cmd.Flags().BoolVar(&useFileStorage, "use-file-storage", false,
+		"Force base64 file storage instead of the OS keyring (useful for headless / CI hosts)")
 	return cmd
 }

--- a/internal/credstore/store.go
+++ b/internal/credstore/store.go
@@ -140,6 +140,12 @@ func (s *Store) Save(token string, requested Backend) (used Backend, err error) 
 			fmt.Fprintf(os.Stderr,
 				"[!] OS keyring unavailable (%v); falling back to file storage at %s\n",
 				err, s.credsPath)
+			// Best-effort: clear any stale keyring entry from a previous
+			// successful login. Without this, a transient Set failure
+			// (e.g. quota / locked but readable keyring) would leave the
+			// old PAT recoverable in the keyring while the new token went
+			// to file. Mirrors the cleanup in the BackendFile branch.
+			_ = keyring.Delete(keyringService, keyringAccount)
 			return s.saveFile(token)
 		}
 		// keyring.Set succeeded. Persist the marker file. On failure we
@@ -169,14 +175,20 @@ func (s *Store) Save(token string, requested Backend) (used Backend, err error) 
 }
 
 // Clean removes the token from BOTH backends and removes the on-disk file
-// entirely. Errors from missing entries are tolerated; the post-condition
-// is "no GitFive-Go credentials remain on this host".
+// entirely. "Not found" errors on either backend are tolerated (idempotent
+// reset), but any *other* failure is surfaced so callers cannot mistakenly
+// report a successful cleanup when a token is still recoverable on disk
+// or in the keyring.
 func (s *Store) Clean() error {
-	_ = keyring.Delete(keyringService, keyringAccount) // best effort
-	if err := os.Remove(s.credsPath); err != nil && !os.IsNotExist(err) {
-		return err
+	var errs []error
+	if err := keyring.Delete(keyringService, keyringAccount); err != nil &&
+		!errors.Is(err, keyring.ErrNotFound) {
+		errs = append(errs, fmt.Errorf("delete keyring entry: %w", err))
 	}
-	return nil
+	if err := os.Remove(s.credsPath); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("remove creds file: %w", err))
+	}
+	return errors.Join(errs...)
 }
 
 func (s *Store) saveFile(token string) (Backend, error) {

--- a/internal/credstore/store.go
+++ b/internal/credstore/store.go
@@ -1,0 +1,196 @@
+// Package credstore persists the fine-grained GitHub PAT used by GitFive-Go.
+// It supports two backends: the host's OS keyring (preferred) and a
+// base64-encoded JSON file under ~/.gitfive_go/. The choice is recorded in
+// the file as a "storage" marker so subsequent reads know where to look.
+package credstore
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/zalando/go-keyring"
+)
+
+// Backend identifies which storage strategy is in effect.
+type Backend string
+
+const (
+	// BackendKeyring stores the token in the OS keyring (Keychain on
+	// macOS, Credential Manager on Windows, Secret Service / libsecret
+	// on Linux). The on-disk file holds only a marker.
+	BackendKeyring Backend = "keyring"
+
+	// BackendFile stores the token inline in the on-disk JSON file.
+	BackendFile Backend = "file"
+)
+
+// Hard-coded keyring identifiers. Single-PAT design — re-saving overwrites.
+const (
+	keyringService = "gitfive-go"
+	keyringAccount = "fine-grained-pat"
+)
+
+// Store persists a single fine-grained PAT.
+type Store struct {
+	credsPath string
+}
+
+// New returns a Store rooted at credsPath (typically ~/.gitfive_go/creds.m).
+func New(credsPath string) *Store {
+	return &Store{credsPath: credsPath}
+}
+
+// CredsPath returns the absolute path to the on-disk marker / fallback file.
+// The Store owns this path; callers must not recompute it from environment
+// because that path can drift if the environment changes mid-run (e.g. tests
+// that rewrite $HOME after construction).
+func (s *Store) CredsPath() string { return s.credsPath }
+
+// onDiskState is the JSON shape persisted as base64 inside credsPath.
+type onDiskState struct {
+	Storage Backend `json:"storage"`
+	Token   string  `json:"token,omitempty"` // present only when Storage == BackendFile
+}
+
+// Load returns the stored token and the backend in use. An empty token
+// (with empty error) means nothing is stored — the caller should treat this
+// as "user has not logged in yet".
+//
+// Legacy v0.1.1 creds.m (which lacks a "storage" field but contains a
+// "token" field) is read transparently as BackendFile so existing users
+// keep working until their next login.
+func (s *Store) Load() (token string, backend Backend, err error) {
+	raw, err := os.ReadFile(s.credsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", "", nil
+		}
+		return "", "", err
+	}
+	decoded, err := base64.StdEncoding.DecodeString(string(raw))
+	if err != nil {
+		return "", "", fmt.Errorf("decode creds: %w", err)
+	}
+
+	var state onDiskState
+	if err := json.Unmarshal(decoded, &state); err != nil {
+		return "", "", fmt.Errorf("parse creds: %w", err)
+	}
+
+	switch state.Storage {
+	case BackendKeyring:
+		tok, err := keyring.Get(keyringService, keyringAccount)
+		if err != nil {
+			if errors.Is(err, keyring.ErrNotFound) {
+				// Marker says keyring, but entry is gone (cleared by
+				// the user, OS update, etc.). Treat as "no token saved"
+				// rather than as an error.
+				return "", BackendKeyring, nil
+			}
+			return "", BackendKeyring, fmt.Errorf("keyring get: %w", err)
+		}
+		return tok, BackendKeyring, nil
+
+	case BackendFile:
+		return state.Token, BackendFile, nil
+
+	case "":
+		// Legacy v0.1.1: no "storage" field. If a "token" key was set we
+		// treat it as file storage; otherwise nothing is stored.
+		var legacy struct {
+			Token string `json:"token"`
+		}
+		_ = json.Unmarshal(decoded, &legacy)
+		if legacy.Token != "" {
+			return legacy.Token, BackendFile, nil
+		}
+		return "", "", nil
+
+	default:
+		return "", "", fmt.Errorf("unknown storage backend %q", state.Storage)
+	}
+}
+
+// Save persists token using the requested backend. If requested is
+// BackendKeyring and the keyring is unavailable, the function falls back to
+// BackendFile and writes a one-line warning to stderr — keeping zero-config
+// installs on D-Bus-less Linux containers and similar environments working.
+//
+// Stale entries on the other backend are best-effort deleted so a rotated
+// PAT does not leave behind a recoverable token on the unused backend.
+func (s *Store) Save(token string, requested Backend) (used Backend, err error) {
+	if token == "" {
+		return "", errors.New("refusing to save empty token")
+	}
+	if err := os.MkdirAll(filepath.Dir(s.credsPath), 0o700); err != nil {
+		return "", fmt.Errorf("ensure creds dir: %w", err)
+	}
+
+	switch requested {
+	case BackendKeyring:
+		if err := keyring.Set(keyringService, keyringAccount, token); err != nil {
+			// We surface the underlying error in the warning because users
+			// debugging headless / D-Bus-less hosts need to know the cause.
+			// `go-keyring` is documented not to embed secrets in its error
+			// strings; if that ever changes this message must be sanitized.
+			fmt.Fprintf(os.Stderr,
+				"[!] OS keyring unavailable (%v); falling back to file storage at %s\n",
+				err, s.credsPath)
+			return s.saveFile(token)
+		}
+		// keyring.Set succeeded. Persist the marker file. On failure we
+		// MUST compensate by deleting the keyring entry; otherwise the
+		// token would be orphaned in the keyring with no marker pointing
+		// at it, leaving the user unable to recover via the CLI.
+		if err := s.writeState(onDiskState{Storage: BackendKeyring}); err != nil {
+			_ = keyring.Delete(keyringService, keyringAccount)
+			return "", err
+		}
+		return BackendKeyring, nil
+
+	case BackendFile:
+		// Persist the file FIRST so that, if the disk write fails, the
+		// previous keyring entry remains usable. Only after the file is
+		// safely written do we clear the now-unused keyring entry.
+		used, err := s.saveFile(token)
+		if err != nil {
+			return "", err
+		}
+		_ = keyring.Delete(keyringService, keyringAccount) // best effort
+		return used, nil
+
+	default:
+		return "", fmt.Errorf("unknown backend %q", requested)
+	}
+}
+
+// Clean removes the token from BOTH backends and removes the on-disk file
+// entirely. Errors from missing entries are tolerated; the post-condition
+// is "no GitFive-Go credentials remain on this host".
+func (s *Store) Clean() error {
+	_ = keyring.Delete(keyringService, keyringAccount) // best effort
+	if err := os.Remove(s.credsPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (s *Store) saveFile(token string) (Backend, error) {
+	if err := s.writeState(onDiskState{Storage: BackendFile, Token: token}); err != nil {
+		return "", err
+	}
+	return BackendFile, nil
+}
+
+func (s *Store) writeState(state onDiskState) error {
+	blob, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded := base64.StdEncoding.EncodeToString(blob)
+	return os.WriteFile(s.credsPath, []byte(encoded), 0o600)
+}

--- a/internal/credstore/store_test.go
+++ b/internal/credstore/store_test.go
@@ -295,6 +295,38 @@ func TestClean_NoOpWhenNothingStored(t *testing.T) {
 	}
 }
 
+func TestClean_SurfacesKeyringDeleteFailure(t *testing.T) {
+	// Regression guard for PR #16 review: when keyring.Delete returns an
+	// error that is NOT ErrNotFound (keyring locked / D-Bus dropped /
+	// platform-specific failure), Clean must propagate it instead of
+	// silently reporting success — otherwise `gitfive-go login --clean`
+	// would tell the user the credentials are gone while the PAT is
+	// still recoverable from the keyring.
+	keyring.MockInitWithError(errors.New("simulated keyring locked"))
+	t.Cleanup(func() { keyring.MockInit() })
+
+	s := newTempStore(t)
+	// Pre-create the marker file so we can confirm the file half of
+	// Clean still completes even when the keyring half fails.
+	if err := os.MkdirAll(filepath.Dir(s.credsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.credsPath, []byte("placeholder"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := s.Clean()
+	if err == nil {
+		t.Fatal("expected error when keyring delete fails")
+	}
+	if !strings.Contains(err.Error(), "keyring") {
+		t.Errorf("error should mention keyring, got: %v", err)
+	}
+	if _, statErr := os.Stat(s.credsPath); !os.IsNotExist(statErr) {
+		t.Errorf("file half of Clean should still complete; statErr=%v", statErr)
+	}
+}
+
 func TestLoad_UnknownStorageReturnsError(t *testing.T) {
 	resetMockKeyring(t)
 	s := newTempStore(t)

--- a/internal/credstore/store_test.go
+++ b/internal/credstore/store_test.go
@@ -1,0 +1,311 @@
+package credstore
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+// resetMockKeyring switches go-keyring to its in-memory mock, wiping any
+// state from prior tests in the same process. Tests that mutate keyring
+// state must not call t.Parallel() because the mock is global.
+func resetMockKeyring(t *testing.T) {
+	t.Helper()
+	keyring.MockInit()
+}
+
+func newTempStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	return New(filepath.Join(dir, "creds.m"))
+}
+
+func TestLoad_NoFileReturnsEmpty(t *testing.T) {
+	resetMockKeyring(t)
+	s := newTempStore(t)
+	tok, backend, err := s.Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "" || backend != "" {
+		t.Errorf("expected empty/empty, got token=%q backend=%q", tok, backend)
+	}
+}
+
+func TestSaveLoad_FileBackend(t *testing.T) {
+	resetMockKeyring(t)
+	s := newTempStore(t)
+	used, err := s.Save("github_pat_TEST_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", BackendFile)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if used != BackendFile {
+		t.Errorf("used = %q, want file", used)
+	}
+
+	tok, backend, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if backend != BackendFile {
+		t.Errorf("backend = %q, want file", backend)
+	}
+	if !strings.HasPrefix(tok, "github_pat_") {
+		t.Errorf("unexpected token returned: %q", tok)
+	}
+}
+
+func TestSaveLoad_KeyringBackend(t *testing.T) {
+	resetMockKeyring(t)
+	s := newTempStore(t)
+	used, err := s.Save("github_pat_KEYRING_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", BackendKeyring)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if used != BackendKeyring {
+		t.Errorf("used = %q, want keyring", used)
+	}
+
+	// File should be a marker only — token must NOT be present in the
+	// on-disk JSON.
+	raw, err := os.ReadFile(s.credsPath)
+	if err != nil {
+		t.Fatalf("read creds.m: %v", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(string(raw))
+	if err != nil {
+		t.Fatalf("decode creds.m: %v", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(decoded, &state); err != nil {
+		t.Fatalf("unmarshal creds.m: %v", err)
+	}
+	if state["storage"] != "keyring" {
+		t.Errorf("storage marker = %v, want keyring", state["storage"])
+	}
+	if _, hasToken := state["token"]; hasToken {
+		t.Errorf("token must not be present on disk in keyring mode: %v", state)
+	}
+
+	tok, backend, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if backend != BackendKeyring {
+		t.Errorf("backend = %q, want keyring", backend)
+	}
+	if !strings.HasPrefix(tok, "github_pat_KEYRING_") {
+		t.Errorf("unexpected token: %q", tok)
+	}
+}
+
+func TestSaveKeyring_FallsBackToFileOnError(t *testing.T) {
+	keyring.MockInitWithError(errors.New("simulated keyring failure"))
+	t.Cleanup(func() { keyring.MockInit() })
+
+	s := newTempStore(t)
+	used, err := s.Save("github_pat_FALLBACK_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", BackendKeyring)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if used != BackendFile {
+		t.Errorf("used = %q, want file (fallback)", used)
+	}
+
+	// File backend should now hold the token inline.
+	tok, backend, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if backend != BackendFile {
+		t.Errorf("backend after fallback = %q, want file", backend)
+	}
+	if !strings.HasPrefix(tok, "github_pat_FALLBACK_") {
+		t.Errorf("unexpected token after fallback: %q", tok)
+	}
+}
+
+func TestSwitchKeyringToFile_DeletesKeyringEntry(t *testing.T) {
+	resetMockKeyring(t)
+	s := newTempStore(t)
+
+	if _, err := s.Save("github_pat_FIRST_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", BackendKeyring); err != nil {
+		t.Fatalf("first Save: %v", err)
+	}
+	if _, err := keyring.Get(keyringService, keyringAccount); err != nil {
+		t.Fatalf("expected entry in keyring after first save, got error: %v", err)
+	}
+
+	if _, err := s.Save("github_pat_SECOND_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", BackendFile); err != nil {
+		t.Fatalf("second Save: %v", err)
+	}
+	if _, err := keyring.Get(keyringService, keyringAccount); !errors.Is(err, keyring.ErrNotFound) {
+		t.Errorf("expected keyring entry to be deleted on switch to file, got err=%v", err)
+	}
+}
+
+func TestSwitchFileToKeyring_RemovesTokenFromDisk(t *testing.T) {
+	resetMockKeyring(t)
+	s := newTempStore(t)
+
+	if _, err := s.Save("github_pat_INFILE_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", BackendFile); err != nil {
+		t.Fatalf("file save: %v", err)
+	}
+	if _, err := s.Save("github_pat_INRING_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", BackendKeyring); err != nil {
+		t.Fatalf("keyring save: %v", err)
+	}
+
+	raw, _ := os.ReadFile(s.credsPath)
+	decoded, _ := base64.StdEncoding.DecodeString(string(raw))
+	if strings.Contains(string(decoded), "github_pat_INFILE_") {
+		t.Errorf("old file-mode token still present on disk after switch to keyring: %s", string(decoded))
+	}
+}
+
+func TestLegacyV011_MigratesToKeyringOnNextSave(t *testing.T) {
+	resetMockKeyring(t)
+	s := newTempStore(t)
+	if err := os.MkdirAll(filepath.Dir(s.credsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-existing v0.1.1 file with inline token.
+	legacy := `{"username":"alice","token":"github_pat_OLDLEGACY_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}`
+	encoded := base64.StdEncoding.EncodeToString([]byte(legacy))
+	if err := os.WriteFile(s.credsPath, []byte(encoded), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// First Save under the new code path moves the token to the keyring
+	// and rewrites the file as a marker only. The OLD inline token must
+	// not survive on disk after migration.
+	if _, err := s.Save("github_pat_NEWFRESH_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", BackendKeyring); err != nil {
+		t.Fatalf("migrating Save: %v", err)
+	}
+
+	raw, _ := os.ReadFile(s.credsPath)
+	decoded, _ := base64.StdEncoding.DecodeString(string(raw))
+	if strings.Contains(string(decoded), "github_pat_OLDLEGACY_") {
+		t.Errorf("legacy token still on disk after migration: %s", string(decoded))
+	}
+	if strings.Contains(string(decoded), "github_pat_NEWFRESH_") {
+		t.Errorf("new token must NOT be on disk in keyring mode, got: %s", string(decoded))
+	}
+
+	tok, backend, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load after migration: %v", err)
+	}
+	if backend != BackendKeyring {
+		t.Errorf("backend after migration = %q, want keyring", backend)
+	}
+	if !strings.HasPrefix(tok, "github_pat_NEWFRESH_") {
+		t.Errorf("token after migration: %q", tok)
+	}
+}
+
+func TestLoad_LegacyV011Schema(t *testing.T) {
+	resetMockKeyring(t)
+	s := newTempStore(t)
+	if err := os.MkdirAll(filepath.Dir(s.credsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-existing v0.1.1 schema: no "storage" field, but has "username"
+	// and "token". Should be read as file backend.
+	legacy := `{"username":"alice","token":"github_pat_LEGACY_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}`
+	encoded := base64.StdEncoding.EncodeToString([]byte(legacy))
+	if err := os.WriteFile(s.credsPath, []byte(encoded), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tok, backend, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if backend != BackendFile {
+		t.Errorf("legacy schema should be read as file backend, got %q", backend)
+	}
+	if !strings.HasPrefix(tok, "github_pat_LEGACY_") {
+		t.Errorf("legacy token mis-read: %q", tok)
+	}
+}
+
+func TestLoad_KeyringMarkerWithoutEntryReturnsEmpty(t *testing.T) {
+	resetMockKeyring(t)
+	s := newTempStore(t)
+	if err := os.MkdirAll(filepath.Dir(s.credsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	encoded := base64.StdEncoding.EncodeToString([]byte(`{"storage":"keyring"}`))
+	if err := os.WriteFile(s.credsPath, []byte(encoded), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tok, backend, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if tok != "" {
+		t.Errorf("token should be empty when keyring has no entry, got %q", tok)
+	}
+	if backend != BackendKeyring {
+		t.Errorf("backend should still be keyring, got %q", backend)
+	}
+}
+
+func TestSave_RejectsEmptyToken(t *testing.T) {
+	resetMockKeyring(t)
+	s := newTempStore(t)
+	if _, err := s.Save("", BackendFile); err == nil {
+		t.Error("expected Save to reject empty token")
+	}
+	if _, err := s.Save("", BackendKeyring); err == nil {
+		t.Error("expected Save to reject empty token in keyring mode")
+	}
+}
+
+func TestClean_RemovesBothBackends(t *testing.T) {
+	resetMockKeyring(t)
+	s := newTempStore(t)
+	if _, err := s.Save("github_pat_CLEAN1_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", BackendKeyring); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Clean(); err != nil {
+		t.Fatalf("Clean: %v", err)
+	}
+	if _, err := os.Stat(s.credsPath); !os.IsNotExist(err) {
+		t.Errorf("creds.m should be deleted, got stat err=%v", err)
+	}
+	if _, err := keyring.Get(keyringService, keyringAccount); !errors.Is(err, keyring.ErrNotFound) {
+		t.Errorf("keyring entry should be deleted, got err=%v", err)
+	}
+}
+
+func TestClean_NoOpWhenNothingStored(t *testing.T) {
+	resetMockKeyring(t)
+	s := newTempStore(t)
+	if err := s.Clean(); err != nil {
+		t.Errorf("Clean on empty store should not error, got %v", err)
+	}
+}
+
+func TestLoad_UnknownStorageReturnsError(t *testing.T) {
+	resetMockKeyring(t)
+	s := newTempStore(t)
+	if err := os.MkdirAll(filepath.Dir(s.credsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	encoded := base64.StdEncoding.EncodeToString([]byte(`{"storage":"satellite"}`))
+	if err := os.WriteFile(s.credsPath, []byte(encoded), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := s.Load(); err == nil {
+		t.Error("expected error on unknown storage backend")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #5. Stores the fine-grained GitHub PAT in the OS keyring (Keychain on macOS, Credential Manager on Windows, Secret Service / libsecret on Linux) instead of a base64-encoded JSON file. Falls back to the existing file storage when the keyring is unavailable, and offers an explicit \`--use-file-storage\` opt-in for users who want file storage even on keyring-capable hosts.

Architectural reasoning is captured in [\`docs/ADR/0001-keyring-credential-store.md\`](docs/ADR/0001-keyring-credential-store.md). Status will move from \`Proposed\` to \`Accepted\` upon merge.

## Why

The base64 file at \`~/.gitfive_go/creds.m\` was inherited from the Python upstream and never offered real protection — any same-user process or backup tool can read it. Since PR #14 the fine-grained PAT now carries \`Administration: Read and write\` on All repositories, raising the cost of a leak. Issue #5 asks for a real OS-level secret store; this PR delivers it.

## What changed

### New package: \`internal/credstore\`

Single \`Store\` type with three operations: \`Load() (token, backend, err)\`, \`Save(token, requested) (used, err)\`, \`Clean() err\`. Two backends:

- **\`BackendKeyring\`** (default): token lives in the OS keyring under \`service=\"gitfive-go\"\`, \`account=\"fine-grained-pat\"\`. The on-disk file holds only \`{\"storage\":\"keyring\"}\`.
- **\`BackendFile\`** (opt-in / fallback): token is base64'd inline in \`creds.m\` as \`{\"storage\":\"file\",\"token\":\"...\"}\`. Same shape as the v0.1.1 file.

Legacy v0.1.1 files (no \`storage\` field, has \`token\` field) are read transparently as file storage so existing users keep working until their next \`gitfive-go login\`.

### Backend selection

- \`gitfive-go login\`: keyring by default. On \`keyring.Set\` error, auto-falls-back to file with a one-line stderr warning, keeping headless / D-Bus-less environments zero-config.
- \`gitfive-go login --use-file-storage\`: forces the file backend, even on keyring-capable hosts. Useful for users who back up dotfiles or prefer portability.
- \`gitfive-go login --clean\`: removes the token from BOTH backends.
- \`gitfive-go login --force\`: same as default but always overwrites; old keyring entry deleted before new write.

### Token rotation safety

Every \`Save\` best-effort clears the unused backend, so a rotated PAT cannot leave a recoverable token behind on the backend you stopped using. Combined with PR #14's 30-day expiry warning, the rotation flow is now self-cleaning.

### Username no longer persisted

\`auth.Credentials.Username\` is in-memory only. \`auth.CheckToken\` rederives it from \`GET /user\` on every login flow (which all command paths trigger), so persisting it produced only stale data after token rotation. The v0.1.1 \`username\` field on disk is silently dropped on next Save.

### Pure Go / static binary

\`zalando/go-keyring\` is pure Go on all three platforms (\`/usr/bin/security\` shell-out on macOS, pure-Go D-Bus on Linux, \`syscall\` on Windows). \`CGO_ENABLED=0\` cross-compiles for all release targets verified locally.

### Hardening (driven by adversarial review)

- **Compensating delete on writeState failure**: in BackendKeyring, if \`keyring.Set\` succeeds but the marker write fails, we \`keyring.Delete\` to avoid orphaning a token in the keyring with no marker file pointing at it.
- **Safe ordering in BackendFile**: file write happens FIRST, keyring entry is cleared only after the file is safely on disk. A disk-write failure never wipes the user's previously valid keyring credential.

## Tests

\`internal/credstore/store_test.go\` (13 cases):

- File <-> keyring round-trip on both backends.
- Legacy v0.1.1 schema read.
- **Migration: legacy file → first Save → token moved to keyring, old token wiped from disk** (the regression that the rotation-safety story depends on).
- Auto-fallback to file on simulated keyring error (\`keyring.MockInitWithError\`).
- Switch keyring → file deletes the keyring entry; switch file → keyring removes the inline token from disk.
- \`Clean\` removes both backends; idempotent on empty store.
- Unknown \`storage\` value rejected; empty token rejected.
- Marker-file-without-keyring-entry returns empty token + keyring backend (graceful "user revoked the keyring entry" path).

\`internal/auth/credentials_test.go\` rewritten to use \`HOME\` (and \`USERPROFILE\` for Windows) redirection plus \`keyring.MockInit()\` so tests are deterministic and don't touch the real OS store. Verifies Save/Load round-trip and that username is NOT persisted.

All existing tests in \`internal/auth/...\` and \`internal/gitcred/...\` continue to pass — the askpass child still loads the token via the same \`auth.NewCredentials() + Load()\` path.

## ADR

[\`docs/ADR/0001-keyring-credential-store.md\`](docs/ADR/0001-keyring-credential-store.md) — sequential numbering (Issue #5 referenced in the body); Status: \`Proposed\` → \`Accepted\` on merge. English; covers context, decision, alternatives, consequences, and follow-ups (Keychain Services CGO binding, GUI inspection docs).

## Adversarial review

Two iterations via Codex (\`codex-rescue\`):

**Round 1** — 5 findings (HIGH×2, MEDIUM×2, LOW×1) + 2 \"missing test\" notes. Outcome:

- HIGH#1 (\`writeState\` failure orphans token in keyring): **fixed** with compensating \`keyring.Delete\`.
- HIGH#2 (BackendFile clears keyring before saving file → data-loss window): **fixed** by reversing order.
- MEDIUM#3 (auto-fallback warning includes underlying keyring error): **declined** with rationale documented in the code — diagnostic value > hypothetical secret leak via the library's error string.
- MEDIUM#4 (\`storePath\` recomputes \`util.GitfiveDir\` independently): **fixed** by exposing \`credstore.Store.CredsPath()\` and delegating.
- LOW#5 (Backend type is plain string): **declined** — internal package, default branch handles invalid values.
- Migration test: **added** (\`TestLegacyV011_MigratesToKeyringOnNextSave\`).

**Round 2** — explicit \"No actionable findings.\" All round-1 fixes verified; spot-checks confirmed the compensating delete, the new BackendFile ordering, and the migration test all behave correctly.

## Verification

- \`go build ./...\` — pass
- \`go vet ./...\` — clean
- \`go test -race ./...\` — all packages pass (credstore: 13/13, auth: 4/4, gitcred: 10/10, scraper / api / etc unchanged)
- \`gofmt -l\` on changed files — clean
- Cross-compile sanity: \`CGO_ENABLED=0\` builds for darwin/arm64, darwin/amd64, linux/amd64, linux/arm64, windows/amd64, windows/arm64 all succeed

## Manual test plan

- [x] On a host with keyring (macOS / GNOME / KDE / Windows): \`gitfive-go login\` → \`[+] Token stored in the OS keyring\`. Inspect Keychain Access / seahorse / Credential Manager to confirm an entry appears under \`gitfive-go\` / \`fine-grained-pat\`. \`creds.m\` contains only the marker (no token substring).
- [x] On the same host: \`gitfive-go user <target>\` runs end-to-end (askpass child also reads from keyring).
- [x] Force fallback: simulate keyring failure (e.g. \`unset DBUS_SESSION_BUS_ADDRESS\` on Linux) → \`gitfive-go login\` prints the auto-fallback warning and writes \`creds.m\` with \`storage:file\` + token.
- [x] \`gitfive-go login --use-file-storage\` on a keyring-capable host → file backend used regardless. Keyring entry from a previous run is removed.
- [x] \`gitfive-go login --clean\` removes both keyring entry AND \`creds.m\`.
- [x] Legacy upgrade: write a v0.1.1-style \`creds.m\` (token inline, no storage field) → \`gitfive-go user <target>\` works (legacy read path) → \`gitfive-go login\` rotates the token to keyring storage and the old inline token is removed from disk.

Closes #5